### PR TITLE
Build a way smaller multi-stage image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM golang:onbuild as builder
+FROM golang:alpine as builder
 WORKDIR /build
 ADD . .
-RUN go get github.com/jsgoecke/tesla \
+RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates \
+    && go get github.com/jsgoecke/tesla \
     && CGO_ENABLED=0 go build -ldflags='-w -s -extldflags "-static"' -a -o /build/main .
 
 FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/ /go/bin/
-ENTRYPOINT ["/go/bin/main"]
+ENTRYPOINT ["/go/bin/main", "-daemon=true"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM golang:onbuild
-RUN mkdir /app
-ADD . /app/
-WORKDIR /app
-RUN go get github.com/jsgoecke/tesla
-RUN go build -o main .
-ENTRYPOINT ["/app/main", "-daemon=true"]
+FROM golang:onbuild as builder
+WORKDIR /build
+ADD . .
+RUN go get github.com/jsgoecke/tesla \
+    && CGO_ENABLED=0 go build -ldflags='-w -s -extldflags "-static"' -a -o /build/main .
+
+FROM scratch
+COPY --from=builder /build/ /go/bin/
+ENTRYPOINT ["/go/bin/main"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ teslaautomatedsentry.exe --daemon true
 You can also run this tool in a simple Docker container.
 Just run this command : 
 ```
-docker run -ti tesla-automated-sentry --env TESLA_SENTRY_EMAIL=<emailaddress> --env TESLA_SENTRY_PASSWORD=<password>
+docker run -ti -d tesla-automated-sentry --env TESLA_SENTRY_EMAIL=<emailaddress> --env TESLA_SENTRY_PASSWORD=<password>
 ```
 This will start the container in daemon mode!
 


### PR DESCRIPTION
Hi Dennis,

This change will allow you to downsize the image from around 700MB to just 7.58MB as it created a static build.

I also removed the hard-coded daemon opt from the entrypoint so you can now also have the docker container output to stdout.
